### PR TITLE
Bash script to set up rssbot on Debian 8 or higher in one step

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@
     /unsubthis - 使用此命令回复想要退订的 RSS 消息即可退订, 不支持 Channel
     /export    - 导出为 OPML
 
+## 一键安装
+
+```bash
+# Debian 8 or higher
+bash <(wget https://raw.githubusercontent.com/iovxw/rssbot/master/rssbot.sh -O -)
+```
+
 ## 下载
 
 可直接从 [Releases](https://github.com/iovxw/rssbot/releases) 下载预编译的程序, Linux 版本为 *musl* 静态链接, 无需其他依赖

--- a/rssbot.sh
+++ b/rssbot.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Debian 8 or higher
+
+[ -w / ] || {
+  echo "You are not running as root. Use su - to get the root privilege at first." >&2
+  exit 1
+}
+
+apt update
+apt install bsdtar -y
+
+tag=$(wget -qO- https://api.github.com/repos/iovxw/rssbot/releases/latest | grep 'tag_name' | cut -d\" -f4)
+
+cd /root && wget -qO- "https://github.com/iovxw/rssbot/releases/download/${tag}/rssbot-${tag}-linux.zip" | bsdtar -xvf-
+chmod +x /root/rssbot
+
+read -p "Please paste telegram bot token for rssbot here: " token
+[ -z "${token}" ]
+
+cat > /lib/systemd/system/rssbot.service<<-EOF
+[Service]
+ExecStart=/root/rssbot DATAFILE ${token}
+EOF
+
+systemctl daemon-reload
+systemctl start rssbot


### PR DESCRIPTION
- Download the latest binary program from release.
- Set up telegram bot api token interactively.
- Use systemd script to launch rssbot automatically.

Cheers.