### PR TITLE
feat: Delete the url in some messages to avoid information leak

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -1,6 +1,6 @@
 rss_size_limit_exceeded = "RSS size limit exceeded （{size}）"
-continuous_fetch_error = "《<a href=\"{link}\">{title}</a>》has been pulled unsuccessfully for 5 consecutive days ({error}). It may have been closed, please unsubscribe."
-feed_renamed = "<a href=\"{link}\">{title}</a> has been renamed to {new_title}"
+continuous_fetch_error = "《{title}》has been pulled unsuccessfully for 5 consecutive days ({error}). It may have been closed, please unsubscribe."
+feed_renamed = "{title} has been renamed to {new_title}"
 network_error = "Network error （{source}）"
 parsing_error = "Parsing error （{source}）"
 commands_in_private_channel = "Please use commands in private chat to manage subscriptions for the channel"

--- a/locales/zh.toml
+++ b/locales/zh.toml
@@ -1,6 +1,6 @@
 rss_size_limit_exceeded = "RSS 超出大小限制（{size}）"
-continuous_fetch_error = "《<a href=\"{link}\">{title}</a>》已经连续 5 天拉取出错 ({error}), 可能已经关闭, 请取消订阅"
-feed_renamed = "<a href=\"{link}\">{title}</a> 已更名为 {new_title}"
+continuous_fetch_error = "《{title}》已经连续 5 天拉取出错 ({error}), 可能已经关闭, 请取消订阅"
+feed_renamed = "{title} 已更名为 {new_title}"
 network_error = "网络错误（{source}）"
 parsing_error = "解析错误（{source}）"
 commands_in_private_channel = "请在私聊中使用命令为频道管理订阅"

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -76,7 +76,6 @@ async fn fetch_and_push_updates(
                 db.lock().await.reset_down_time(&feed.link);
                 let msg = tr!(
                     "continuous_fetch_error",
-                    link = Escape(&feed.link),
                     title = Escape(&feed.title),
                     error = Escape(&e.to_user_friendly())
                 );
@@ -115,7 +114,6 @@ async fn fetch_and_push_updates(
             FeedUpdate::Title(new_title) => {
                 let msg = tr!(
                     "feed_renamed",
-                    link = Escape(&feed.link),
                     title = Escape(&feed.title),
                     new_title = Escape(&new_title)
                 );


### PR DESCRIPTION
Some user may use their private token in rss url, post error message to channel may leak these tokens.