### PR TITLE
Allow token to be specified via env var

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -63,7 +63,7 @@ OPTIONS:
         --min-interval <seconds>    Minimum fetch interval [default: 300]
 
 ARGS:
-    <token>    Telegram bot token
+    <token>    Telegram bot token [env: RSSBOT_TOKEN]
 
 NOTE: You can get <user id> using bots like @userinfobot @getidsbot
 ```
@@ -72,6 +72,7 @@ Please read the [official docs](https://core.telegram.org/bots#3-how-do-i-create
 
 ## Environment variables
 
+- `RSSBOT_TOKEN`: Telegram bot token
 - `HTTP_PROXY`: Proxy for HTTP
 - `HTTPS_PROXY`: Proxy for HTTPS
 - `RSSBOT_DONT_PROXY_FEEDS`: Set to `1` to limit the proxy to Telegram requests

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ OPTIONS:
         --min-interval <seconds>    Minimum fetch interval [default: 300]
 
 ARGS:
-    <token>    Telegram bot token
+    <token>    Telegram bot token [env: RSSBOT_TOKEN]
 
 NOTE: You can get <user id> using bots like @userinfobot @getidsbot
 ```
@@ -70,6 +70,7 @@ NOTE: You can get <user id> using bots like @userinfobot @getidsbot
 
 ## 环境变量
 
+- `RSSBOT_TOKEN`: Telegram bot token
 - `HTTP_PROXY`: 用于 HTTP 的代理
 - `HTTPS_PROXY`: 用于 HTTPS 的代理
 - `RSSBOT_DONT_PROXY_FEEDS`: 设为 `1` 使所有订阅的 RSS 不通过代理（仅代理 Telegram）

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,10 @@ static BOT_ID: OnceLock<tbot::types::user::Id> = OnceLock::new();
 )]
 pub struct Opt {
     /// Telegram bot token
+    #[structopt(
+        env = "RSSBOT_TOKEN",
+        hide_env_values = true
+    )]
     token: String,
     /// Path to database
     #[structopt(


### PR DESCRIPTION
The bot token is currently given via command arguments, which are visible to unprivileged processes. Such sensitive data are better suited to be given via environment variables. This PR enables that.